### PR TITLE
Add GDPS mod tag

### DIFF
--- a/src/project/ModJson.ts
+++ b/src/project/ModJson.ts
@@ -546,6 +546,7 @@ export type Tag =
 	"customization" |
 	"content" |
 	"developer" |
+	"gdps" |
 	"cheat" |
 	"paid" |
 	"joke" |


### PR DESCRIPTION
Following the pull request on geode-sdk/server:
Adds a mod tag for mods made for Geometry Dash Private Servers (GDPSs)